### PR TITLE
add set addr error handling

### DIFF
--- a/start-mon.sh
+++ b/start-mon.sh
@@ -115,9 +115,18 @@ if [ "$RESULT" = "0" ]; then
 		re="^([a-fA-F0-9]{2}:){5}[a-fA-F0-9]{2}$"
 		while [[ ! "$iface_addr" =~ $re ]]
 		do
-			read -p " Invalid addr, try again: " iface_addr
+			read -p " Invalid addr format, try again: " iface_addr
 		done
 		ip link set dev "$iface0" address "$iface_addr"
+		while [[ $? -ne 0 ]]
+		do
+			read -p " Setting addr failed, try again: " iface_addr
+			while [[ ! "$iface_addr" =~ $re ]]
+			do
+				read -p " Invalid addr format, try again: " iface_addr
+			done
+			ip link set dev "$iface0" address "$iface_addr"
+		done
 	fi
 
 


### PR DESCRIPTION
Added some additional error handling:

```
 --------------------------------
    start-mon.sh 20230206
 --------------------------------
    WiFi Interface:
             wlp0s20f0u1
 --------------------------------
    name  -  wlp0s20f0u1
    type  -  managed
    state -  DOWN
    addr  -  XX:XX:XX:XX:XX:XX
 --------------------------------

 Do you want to set a new addr? [y/N] y
 What addr do you want? ( e.g. 12:34:56:78:90:ab ) 123
 Invalid addr format, try again: 123
 Invalid addr format, try again: 11:11:11:11:11:11
RTNETLINK answers: Operation not permitted
 Setting addr failed, try again: asd
 Invalid addr format, try again: 123
 Invalid addr format, try again: 11:11:11:11:11:11
RTNETLINK answers: Operation not permitted
 Setting addr failed, try again: 1
 Invalid addr format, try again: 12:12:12:12:12:12
```
```
 --------------------------------
    start-mon.sh 20230206
 --------------------------------
    WiFi Interface:
             wlp0s20f0u1
 --------------------------------
    name  -  wlan0mon
    type  -  monitor
    state -  DORMANT
    addr  -  12:12:12:12:12:12
    chan  -  1 (2412 MHz), width: 20 MHz (no HT), center1: 2412 MHz
 --------------------------------

 Do you want to set the channel? [y/N] 
```