### PR TITLE
extend txpw info

### DIFF
--- a/start-mon.sh
+++ b/start-mon.sh
@@ -213,6 +213,7 @@ if [ "$RESULT" = "0" ]; then
 	if [[ $REPLY =~ ^[Yy]$ ]]
 	then
 		echo " Note: Some USB WiFi adapters will not allow the txpw to be set."
+		echo "       Be careful because some adapters will let you increase power to the point that you will burn the adapter."
 		read -p " What txpw setting do you want to attempt to set? ( e.g. 2300 = 23 dBm ) " iface_txpw
 		iw dev $iface0mon set txpower fixed "$iface_txpw"
 	fi


### PR DESCRIPTION
Added your [comment](https://github.com/morrownr/8821au-20210708/issues/70#issuecomment-1424601652) to the txpw info.

Before:
```
 Do you want to set the txpower? [y/N] y
 Note: Some USB WiFi adapters will not allow the txpw to be set.
 What txpw setting do you want to attempt to set? ( e.g. 2300 = 23 dBm ) 
```

After:
```
 Do you want to set the txpower? [y/N] y
 Note: Some USB WiFi adapters will not allow the txpw to be set.
       Be careful because some adapters will let you increase power to the point that you will burn the adapter.
 What txpw setting do you want to attempt to set? ( e.g. 2300 = 23 dBm ) 
```