### PR TITLE
add codespell CI

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,28 @@
+name: Codespell CI
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  push:
+    branches: [ main ]
+
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  codespell:
+    name: Codespell CI
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Install dependencies
+        run: sudo apt update -y && sudo apt install -y codespell
+
+      - name: Run codespell
+        run: codespell

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Monitor_Mode
 
+[![Codespell CI](https://github.com/morrownr/Monitor_Mode/actions/workflows/codespell.yml/badge.svg?event=push)](https://github.com/morrownr/Monitor_Mode/actions/workflows/codespell.yml)
 [![Shellcheck CI](https://github.com/morrownr/Monitor_Mode/actions/workflows/shellcheck.yml/badge.svg?event=push)](https://github.com/morrownr/Monitor_Mode/actions/workflows/shellcheck.yml)
 
 Purpose: Provide information and tools for starting and using monitor mode with Linux.


### PR DESCRIPTION
Added a [codespell](https://github.com/codespell-project/codespell) CI. `codespell` reports common typos, for example:

after deliberately adding a typo to README:
```
...
Purpose: Provdie information ...
...
```

```
$ codespell
./README.md:6: Provdie ==> Provide
$ echo $?
65
```

after fixing it:
```
$ codespell
$ echo $?  
0
```