### PR TITLE
add markdown link check CI

### DIFF
--- a/.github/workflows/markdown-link.yml
+++ b/.github/workflows/markdown-link.yml
@@ -1,0 +1,24 @@
+name: "Markdown link CI"
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  push:
+    branches: [ main ]
+    paths:
+      - .github/workflows/markdown-link.yml
+      - '**.md'
+
+  pull_request:
+    branches: [ main ]
+    paths:
+      - .github/workflows/markdown-link.yml
+      - '**.md'
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Monitor_Mode
 
 [![Codespell CI](https://github.com/morrownr/Monitor_Mode/actions/workflows/codespell.yml/badge.svg?event=push)](https://github.com/morrownr/Monitor_Mode/actions/workflows/codespell.yml)
+[![Markdown link CI](https://github.com/morrownr/Monitor_Mode/actions/workflows/markdown-link.yml/badge.svg?event=push)](https://github.com/morrownr/Monitor_Mode/actions/workflows/markdown-link.yml)
 [![Shellcheck CI](https://github.com/morrownr/Monitor_Mode/actions/workflows/shellcheck.yml/badge.svg?event=push)](https://github.com/morrownr/Monitor_Mode/actions/workflows/shellcheck.yml)
 
 Purpose: Provide information and tools for starting and using monitor mode with Linux.


### PR DESCRIPTION
Added a [CI](https://github.com/marketplace/actions/markdown-link-check) to check markdown files for broken links.