### PR TITLE
make interface renaming more generic

### DIFF
--- a/start-mon.sh
+++ b/start-mon.sh
@@ -48,12 +48,7 @@ iface0=${1}
 
 
 # assign monitor mode interface name
-if [ "$iface0" = "wlan0" ]; then
-	iface0mon="wlan0mon"
-fi
-if [ "$iface0" = "wlan1" ]; then
-	iface0mon="wlan1mon"
-fi
+iface0mon="${iface0}mon"
 
 
 # assign default channel

--- a/start-mon.sh
+++ b/start-mon.sh
@@ -152,7 +152,7 @@ if [ "$RESULT" = "0" ]; then
 #	info:	In-kernel drivers do not have the above problems.
 #
 # option 1: rename interface to the value in $iface0mon
-	ip link set dev "$iface0" name $iface0mon
+	ip link set dev "$iface0" name "$iface0mon"
 #
 # option 2: keep the original system interface name
 #	iface0mon="$iface0"


### PR DESCRIPTION
Fixes #11 

I encountered some problems after I pulled the updated interface renaming code: the name of my interface is `wlp0s20f0u1` but the script expects either `wlan0` or `wlan1`:

```
if [ "$iface0" = "wlan0" ]; then
	iface0mon="wlan0mon"
fi
if [ "$iface0" = "wlan1" ]; then
	iface0mon="wlan1mon"
fi
```

So `iface0mon` is empty in my case and this causes problems. This PR fixes this by making this code more generic:

```
iface0mon="${iface0}mon"
```