### PR TITLE
add missing $ (follow-up of fix of interface naming issue)

### DIFF
--- a/start-mon.sh
+++ b/start-mon.sh
@@ -151,10 +151,10 @@ if [ "$RESULT" = "0" ]; then
 #	info:	In-kernel drivers do not have the above problems.
 #
 	iface0mon="$iface0"
-	if [ "iface0mon" = "wlan0" ]; then
+	if [ "$iface0mon" = "wlan0" ]; then
 		iface0mon="wlan0mon"
 	fi
-	if [ "iface0mon" = "wlan1" ]; then
+	if [ "$iface0mon" = "wlan1" ]; then
 		iface0mon="wlan1mon"
 	fi
 	ip link set dev "$iface0" name $iface0mon


### PR DESCRIPTION
Fixes #11

https://github.com/morrownr/Monitor_Mode/commit/39caa727181e0b008150b455456f74f3f30c1840 fixes #11 but there are 2 `$` missing so I added them:

```
	iface0mon="$iface0"
	if [ "iface0mon" = "wlan0" ]; then
		iface0mon="wlan0mon"
	fi
	if [ "iface0mon" = "wlan1" ]; then
		iface0mon="wlan1mon"
	fi
	ip link set dev "$iface0" name $iface0mon
```